### PR TITLE
Show all command types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # FindFunctionCalls
 
+## 1.2.0
+
+- Show all command types
+    - Only functions are analysed for further nested calls
+- Improve error messages when command resolution fails
+- Show calls when command resolution fails
+
 ## 1.1.2
 
 - Fix positional binding for `-Name` and `-Function` parameters

--- a/Classes/FunctionCallInfo.ps1
+++ b/Classes/FunctionCallInfo.ps1
@@ -44,12 +44,23 @@ class FunctionCallInfo
     )
 
 
+    FunctionCallInfo ([string]$Name)
+    {
+        $this.Name = $Name
+        $this.Initialise()
+    }
+
     FunctionCallInfo ([Management.Automation.FunctionInfo]$Function)
     {
         $this.Function = $Function
         $this.Name = $Function.Name
         $this.Source = $Function.Source
         $this.Module = $Function.Module
+        $this.Initialise()
+    }
+
+    [void] Initialise()
+    {
         $this.Calls = [Collections.Generic.List[FunctionCallInfo]]::new()
 
         [FunctionCallInfo]::_InheritedProperties | ForEach-Object {
@@ -63,16 +74,39 @@ class FunctionCallInfo
 
     [bool] Equals([object]$obj)
     {
-        return $this.Function.Equals($obj)
+        if ($this.Function)
+        {
+            return $this.Function.Equals($obj)
+        }
+        else
+        {
+            return $this.Name -eq $Obj.Name -and
+            $this.Source -eq $Obj.Source -and
+            $this.Module -eq $Obj.Module
+        }
     }
 
     [Management.Automation.ParameterMetadata] ResolveParameter([string]$name)
     {
-        return $this.Function.ResolveParameter($name)
+        if ($this.Function)
+        {
+            return $this.Function.ResolveParameter($name)
+        }
+        else
+        {
+            throw [InvalidOperationException]::new("Cannot resolve parameter for unresolved command '$($this.Name)'.")
+        }
     }
 
     [string] ToString()
     {
-        return $_.Function.ToString()
+        if ($this.Function)
+        {
+            return $_.Function.ToString()
+        }
+        else
+        {
+            return $this.Name
+        }
     }
 }

--- a/Classes/FunctionCallInfo.ps1
+++ b/Classes/FunctionCallInfo.ps1
@@ -18,7 +18,7 @@ class IFunctionCallInfo
     [int]$Depth
 
     # Inner object; we'll delegate calls to this
-    hidden [Management.Automation.FunctionInfo]$Function
+    hidden [Management.Automation.CommandInfo]$Command
 
 
     IFunctionCallInfo()
@@ -55,7 +55,7 @@ class IFunctionCallInfo
         )
 
         $InheritedProperties | ForEach-Object {
-            Add-Member ScriptProperty -InputObject $this -Name $_ -Value ([scriptblock]::Create("`$this.Function.$_"))
+            Add-Member ScriptProperty -InputObject $this -Name $_ -Value ([scriptblock]::Create("`$this.Command.$_"))
         }
     }
 
@@ -68,27 +68,27 @@ class IFunctionCallInfo
 
 class FunctionCallInfo : IFunctionCallInfo
 {
-    FunctionCallInfo([Management.Automation.FunctionInfo]$Function) : base()
+    FunctionCallInfo([Management.Automation.CommandInfo]$Command) : base()
     {
-        $this.Function = $Function
-        $this.Name = $Function.Name
-        $this.Source = $Function.Source
-        $this.Module = $Function.Module
+        $this.Command = $Command
+        $this.Name = $Command.Name
+        $this.Source = $Command.Source
+        $this.Module = $Command.Module
     }
 
     [bool] Equals([object]$obj)
     {
-        return $this.Function.Equals($obj)
+        return $this.Command.Equals($obj)
     }
 
     [Management.Automation.ParameterMetadata] ResolveParameter([string]$name)
     {
-        return $this.Function.ResolveParameter($name)
+        return $this.Command.ResolveParameter($name)
     }
 
     [string] ToString()
     {
-        return $_.Function.ToString()
+        return $_.Command.ToString()
     }
 }
 

--- a/FindFunctionCalls.Format.ps1xml
+++ b/FindFunctionCalls.Format.ps1xml
@@ -6,7 +6,7 @@
     <View>
         <Name>FunctionCallInfo</Name>
         <ViewSelectedBy>
-          <TypeName>FunctionCallInfo</TypeName>
+          <TypeName>IFunctionCallInfo</TypeName>
         </ViewSelectedBy>
         <TableControl>
 

--- a/FindFunctionCalls.Format.ps1xml
+++ b/FindFunctionCalls.Format.ps1xml
@@ -29,9 +29,7 @@
             <TableRowEntry>
               <TableColumnItems>
                 <TableColumnItem>
-                  <ScriptBlock>
-                      $_.Function.CommandType
-                  </ScriptBlock>
+                  <PropertyName>CommandType</PropertyName>
                 </TableColumnItem>
                 <TableColumnItem>
                   <ScriptBlock>

--- a/FindFunctionCalls.psd1
+++ b/FindFunctionCalls.psd1
@@ -1,6 +1,6 @@
 @{
     Description          = 'Build a tree of function calls.'
-    ModuleVersion        = '1.1.2'
+    ModuleVersion        = '1.2.0'
     HelpInfoURI          = 'https://pages.github.com/fsackur/FindFunctionCalls'
 
     GUID                 = '7b5c6e30-13b1-4ff8-a3ca-f1151b346066'

--- a/Public/Find-FunctionCall.ps1
+++ b/Public/Find-FunctionCall.ps1
@@ -69,7 +69,7 @@ function Find-FunctionCall
         [int]$Depth = 4,
 
         [Parameter(DontShow, ParameterSetName = 'Recursing', Mandatory, ValueFromPipeline)]
-        [FunctionCallInfo]$CallingFunction,
+        [IFunctionCallInfo]$CallingFunction,
 
         [Parameter(DontShow, ParameterSetName = 'Recursing')]
         [int]$_CallDepth = 0,

--- a/Public/Find-FunctionCall.ps1
+++ b/Public/Find-FunctionCall.ps1
@@ -130,7 +130,7 @@ function Find-FunctionCall
 
         $CalledCommands = if ($Function.Module)
         {
-            & $Function.Module {$args | Get-Command} $CalledCommandNames
+            $Function.Module.Invoke({$args | Get-Command}, @(,$CalledCommandNames))
         }
         else
         {

--- a/Public/Find-FunctionCall.ps1
+++ b/Public/Find-FunctionCall.ps1
@@ -94,7 +94,7 @@ function Find-FunctionCall
 
         if ($PSCmdlet.ParameterSetName -eq 'Recursing')
         {
-            $Function = $CallingFunction.Function
+            $Function = $CallingFunction.Command
         }
         else
         {

--- a/Public/Find-FunctionCall.ps1
+++ b/Public/Find-FunctionCall.ps1
@@ -33,24 +33,24 @@ function Find-FunctionCall
         .EXAMPLE
         'Install-Module' | Get-Command | Find-FunctionCall
 
-        CommandType Name                                          Version Source
-        ----------- ----                                          ------- ------
-        Function    Install-Module                                2.2.5   PowerShellGet
-        Function      Get-ProviderName                            2.2.5   PowerShellGet
-        Function      Get-PSRepository                            2.2.5   PowerShellGet
-        Function        New-ModuleSourceFromPackageSource         2.2.5   PowerShellGet
-        Function      Install-NuGetClientBinaries                 2.2.5   PowerShellGet
-        Function        Get-ParametersHashtable                   2.2.5   PowerShellGet
-        Function        Test-RunningAsElevated                    2.2.5   PowerShellGet
-        Function        ThrowError                                2.2.5   PowerShellGet
-        Function      New-PSGetItemInfo                           2.2.5   PowerShellGet
-        Function        Get-EntityName                            2.2.5   PowerShellGet
-        Function        Get-First                                 2.2.5   PowerShellGet
-        Function        Get-SourceLocation                        2.2.5   PowerShellGet
-        Function          Set-ModuleSourcesVariable               2.2.5   PowerShellGet
-        Function            DeSerialize-PSObject                  2.2.5   PowerShellGet
-        Function            Get-PublishLocation                   2.2.5   PowerShellGet
-        Function            Get-ScriptSourceLocation              2.2.5   PowerShellGet
+        CommandType Name                                          Version   Source
+        ----------- ----                                          -------   ------
+        Function    Install-Module                                2.2.5     PowerShellGet
+        Cmdlet        Get-Member                                  7.0.0.0   Microsoft.PowerShell.Utility
+        Function      Get-ProviderName                            2.2.5     PowerShellGet
+        Cmdlet          Get-Member                                7.0.0.0   Microsoft.PowerShell.Utility
+        Function      Get-PSRepository                            2.2.5     PowerShellGet
+        Cmdlet          ForEach-Object                            7.2.5.500 Microsoft.PowerShell.Core
+        Function        New-ModuleSourceFromPackageSource         2.2.5     PowerShellGet
+        Cmdlet            ForEach-Object                          7.2.5.500 Microsoft.PowerShell.Core
+        Cmdlet            New-Object                              7.0.0.0   Microsoft.PowerShell.Utility
+        Cmdlet            Write-Output                            7.0.0.0   Microsoft.PowerShell.Utility
+        Cmdlet          Get-PackageSource                         1.4.7     PackageManagement
+        Function      Install-NuGetClientBinaries                 2.2.5     PowerShellGet
+        Cmdlet          Get-Command                               7.2.5.500 Microsoft.PowerShell.Core
+        Function        Get-ParametersHashtable                   2.2.5     PowerShellGet
+        Cmdlet          Get-Command                               7.2.5.500 Microsoft.PowerShell.Core
+        Cmdlet          Where-Object                              7.2.5.500 Microsoft.PowerShell.Core
 
         For the 'Install-Module' command from the PowerShellGet module, determine the call tree.
     #>


### PR DESCRIPTION
- FunctionCallInfo supports placeholder objects
- Split FunctionCallInfo into base and two children
- Fix resolution of non-exported commands
- FunctionCallInfo can be instantiated from CommandInfo
- Resolve all command types; better error messages
- Update example in help block
- Version bump
